### PR TITLE
Set enablePreemptiveAuthentication.

### DIFF
--- a/extension/src/com/zextras/dav/DavSoapConnector.java
+++ b/extension/src/com/zextras/dav/DavSoapConnector.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashSet;
 import java.util.List;
+import java.net.URL;
 
 import org.apache.commons.codec.binary.Base64InputStream;
 
@@ -43,6 +44,11 @@ public class DavSoapConnector
 
     mSardine = SardineFactory.begin(username, password);
     mSardine.enableCompression();
+    try {                                                                                                                                                                   
+        mSardine.enablePreemptiveAuthentication(new URL(url));
+    } catch(Exception ex) {
+
+    }
   }
 
   /**


### PR DESCRIPTION
-Set enablePreemptiveAuthentication on Sardine object creation to avoid 401 response on every dav request.
-This fixes bug with PUT method due missing auth headers.